### PR TITLE
IgnoreBasePath option to skip validation of requests without base path prefix

### DIFF
--- a/internal/testdata/sample_open_api_v2.yaml
+++ b/internal/testdata/sample_open_api_v2.yaml
@@ -670,6 +670,9 @@ definitions:
         type: integer
       phone:
         type: string
+      birthday:
+        type: string
+        format: date
       user_status:
         type: integer
         format: int32

--- a/mapper.go
+++ b/mapper.go
@@ -2,14 +2,15 @@ package revisor
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
 
-func newSimpleMapper(templateMap map[string][]string) *simpleMapper {
+func newSimpleMapper(basePath string, templateMap map[string][]string) *simpleMapper {
 
-	router := mux.NewRouter().StrictSlash(true)
-	mapper := &simpleMapper{router: router}
+	router := mux.NewRouter().StrictSlash(true).PathPrefix(basePath).Subrouter()
+	mapper := &simpleMapper{router: router, basePath: basePath}
 	for k, v := range templateMap {
 		for _, tmpl := range v {
 			router.Methods(k).Path(tmpl)
@@ -20,7 +21,8 @@ func newSimpleMapper(templateMap map[string][]string) *simpleMapper {
 }
 
 type simpleMapper struct {
-	router *mux.Router
+	router   *mux.Router
+	basePath string
 }
 
 // mapRequest returns configured template that matches HTTP
@@ -35,7 +37,7 @@ func (s *simpleMapper) mapRequest(r *http.Request) (tmpl string, vars map[string
 		if err != nil {
 			return "", nil, false
 		}
-		return tmpl, match.Vars, true
+		return strings.TrimPrefix(tmpl, s.basePath), match.Vars, true
 	}
 	return "", nil, false
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSimpleMapper_New(t *testing.T) {
-	mapper := newSimpleMapper(map[string][]string{
+	mapper := newSimpleMapper("", map[string][]string{
 		"GET": []string{"/path", "/path/{id}"},
 	})
 	assert.NotNil(t, mapper)
@@ -17,7 +17,7 @@ func TestSimpleMapper_New(t *testing.T) {
 
 func TestSimpleMapper_MapRequest(t *testing.T) {
 
-	mapper := newSimpleMapper(map[string][]string{
+	mapper := newSimpleMapper("", map[string][]string{
 		"GET": []string{"/path", "/path/{id}"},
 	})
 	mapper.router.Methods("OPTIONS")

--- a/revisor.go
+++ b/revisor.go
@@ -47,6 +47,9 @@ func IgnoreBasePath(a *apiVerifier) {
 // satisfies OpenAPI definition constraints
 func NewRequestVerifier(definitionPath string, options ...option) (func(*http.Request) error, error) {
 	a, err := newAPIVerifier(definitionPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create verifier function")
+	}
 	a.setOptions(options...)
 	err = a.initMapper(a.doc.Spec().BasePath)
 	if err != nil {
@@ -59,6 +62,9 @@ func NewRequestVerifier(definitionPath string, options ...option) (func(*http.Re
 // and the response made in the context of the request
 func NewVerifier(definitionPath string, options ...option) (func(*http.Response, *http.Request) error, error) {
 	a, err := newAPIVerifier(definitionPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create verifier function")
+	}
 	a.setOptions(options...)
 
 	err = a.initMapper(a.doc.Spec().BasePath)


### PR DESCRIPTION
IgnoreBasePath option to skip validation of requests without base path prefix
closes #26 